### PR TITLE
[QPD-389] Updated version 

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -10,4 +10,4 @@ store the current version info of the notebook.
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
 
-__version__ = 'plt.5552.2'
+__version__ = '1.0.dev389'


### PR DESCRIPTION
We needed to change the `_version` format, which the latest PIP no longer supports.

